### PR TITLE
Add can talk submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/moa/cone-detection/cone_detection/yolov7"]
 	path = src/perception/cone-detection/cone_detection/yolov7
 	url = https://github.com/WongKinYiu/yolov7.git
+[submodule "src/hardware_drivers/CanTalk"]
+	path = src/hardware_drivers/CanTalk
+	url = https://github.com/UOA-FSAE/CanTalk.git


### PR DESCRIPTION
Add can talk submodule that lets you talk using the candapter using the ros2 can messages defined in autonomous. 